### PR TITLE
Add LazyPredict MLflow example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+mlruns/
+lazypredict_results.csv
+output.txt
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Data Science Tools
+
+This repository contains notebooks and scripts exploring various data science tools.
+
+## LazyPredict with MLflow
+
+`lazypredict_mlflow.py` demonstrates how to use **LazyPredict** to quickly train a variety of classification models on the iris dataset. The script logs model accuracies and the result table to **MLflow** for experiment tracking.
+
+### Usage
+
+```bash
+pip install lazypredict mlflow scikit-learn pandas
+python lazypredict_mlflow.py
+```
+
+Running the script will print a table of model performance and create an `mlruns` directory with the MLflow experiment.

--- a/lazypredict_mlflow.py
+++ b/lazypredict_mlflow.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from lazypredict.Supervised import LazyClassifier
+import mlflow
+
+
+def main():
+    data = load_iris(as_frame=True)
+    X, y = data.data, data.target
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    clf = LazyClassifier(verbose=0, ignore_warnings=True)
+    models, predictions = clf.fit(X_train, X_test, y_train, y_test)
+
+    # save results for reference
+    models.to_csv("lazypredict_results.csv")
+    print(models)
+
+    mlflow.set_experiment("lazypredict_iris")
+    with mlflow.start_run():
+        mlflow.log_param("dataset", "iris")
+        for model_name, row in models.iterrows():
+            mlflow.log_metric(f"{model_name}_accuracy", row["Accuracy"])
+        mlflow.log_artifact("lazypredict_results.csv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an example script `lazypredict_mlflow.py` that trains multiple classifiers on the Iris dataset with LazyPredict and logs results to MLflow
- ignore artifacts with `.gitignore`
- document how to run the new script in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405c726fd8832ea572a898658e1a8a